### PR TITLE
zephyr: reference local Kconfig

### DIFF
--- a/zephyr/Kconfig
+++ b/zephyr/Kconfig
@@ -1,0 +1,3 @@
+if SOF
+rsource "../Kconfig"
+endif

--- a/zephyr/module.yml
+++ b/zephyr/module.yml
@@ -1,2 +1,3 @@
 build:
-        cmake: ./zephyr
+  cmake: ./zephyr
+  kconfig: ./zephyr/Kconfig


### PR DESCRIPTION
Reference Kconfig in zephyr module file which is evaluated by Zephyr
directly. This will eliminate the need for including the SOF Kconfig
directly.

Signed-off-by: Anas Nashif <anas.nashif@intel.com>