### PR TITLE
rimage: set correct rimage path in cache

### DIFF
--- a/zephyr/CMakeLists.txt
+++ b/zephyr/CMakeLists.txt
@@ -53,7 +53,7 @@ set(SOF_TRACE_PATH "${SOF_SRC_PATH}/trace")
 
 # Save path to rimage configuration files in cmake cache for later use by
 # rimage during the "west sign" stage
-get_filename_component(RIMAGE_CONFIG "../rimage/config" ABSOLUTE)
+get_filename_component(RIMAGE_CONFIG "ext/rimage/config" ABSOLUTE)
 set(RIMAGE_CONFIG_PATH ${RIMAGE_CONFIG} CACHE PATH
     " Path to rimage board configuration files")
 


### PR DESCRIPTION
rimage in this repo is in zephyr/ext, so set the variable accordingly.

Signed-off-by: Anas Nashif <anas.nashif@intel.com>