### PR TITLE
inhibit warnings on tests of deprecated kwork API

### DIFF
--- a/src/schedule/timer_domain.c
+++ b/src/schedule/timer_domain.c
@@ -24,6 +24,16 @@
 #include <kernel.h>
 #include <sys_clock.h>
 
+/* Paper tape over use of deprecated kwork API.  This should get
+ * addressed before the release, but do this to make forward progress
+ * on being able to deprecated the APIs in general.
+ */
+#include <toolchain.h>
+#undef __deprecated
+#define __deprecated
+#undef __DEPRECATED_MACRO
+#define __DEPRECATED_MACRO
+
 /*
  * Currently the Zephyr clock rate is part it's Kconfig known at build time.
  * SOF on Intel CAVS platforms currently only aligns with Zephyr when both

--- a/zephyr/edf_schedule.c
+++ b/zephyr/edf_schedule.c
@@ -13,6 +13,16 @@
 #include <kernel.h>
 #include <sys_clock.h>
 
+/* Paper tape over use of deprecated kwork API.  This should get
+ * addressed before the release, but do this to make forward progress
+ * on being able to deprecated the APIs in general.
+ */
+#include <toolchain.h>
+#undef __deprecated
+#define __deprecated
+#undef __DEPRECATED_MACRO
+#define __DEPRECATED_MACRO
+
 struct k_work_q edf_workq;
 K_THREAD_STACK_DEFINE(edf_workq_stack, 8192);
 

--- a/zephyr/wrapper.c
+++ b/zephyr/wrapper.c
@@ -28,6 +28,13 @@
 #error Define CONFIG_DYNAMIC_INTERRUPTS
 #endif
 
+
+/* TODO bring back zephyr MAX implementation which is used by the logging in
+ * that file.
+ */
+#undef MAX
+#define MAX(a, b) (((a) > (b)) ? (a) : (b))
+
 /*
  * Memory - Create Zephyr HEAP for SOF.
  *


### PR DESCRIPTION
paper tape over the deprecation warnings for the kwork API.  This
is just meant as a stop gap to be able to mark the APIs as deprecated
and should get properly fixed before the release.

Signed-off-by: Kumar Gala <kumar.gala@linaro.org>