### PR TITLE
zephyr: redefine MAX macro to the generic one

### DIFF
--- a/zephyr/wrapper.c
+++ b/zephyr/wrapper.c
@@ -28,6 +28,13 @@
 #error Define CONFIG_DYNAMIC_INTERRUPTS
 #endif
 
+
+/* TODO bring back zephyr MAX implementation which is used by the logging in
+ * that file.
+ */
+#undef MAX
+#define MAX(a, b) (((a) > (b)) ? (a) : (b))
+
 /*
  * Memory - Create Zephyr HEAP for SOF.
  *


### PR DESCRIPTION
SOF is redefining MAX() to version which cannot be used in
BUILD_ASSERT and logging is using it there. Redefining MAX
to generic version which can be used everywhere.

Signed-off-by: Krzysztof Chruscinski <krzysztof.chruscinski@nordicsemi.no>