### PR TITLE
zephyr: update SYS_INIT calls

### DIFF
--- a/src/init/init.c
+++ b/src/init/init.c
@@ -340,9 +340,8 @@ int sof_main(int argc, char *argv[])
 
 struct device;
 
-static int sof_init(const struct device *dev)
+static int sof_init(void)
 {
-	ARG_UNUSED(dev);
 
 	return primary_core_init(0, NULL, &sof);
 }

--- a/zephyr/lib/alloc.c
+++ b/zephyr/lib/alloc.c
@@ -347,9 +347,8 @@ void rfree(void *ptr)
 	heap_free(&sof_heap, ptr);
 }
 
-static int heap_init(const struct device *unused)
+static int heap_init(void)
 {
-	ARG_UNUSED(unused);
 
 	sys_heap_init(&sof_heap.heap, heapmem, HEAPMEM_SIZE);
 

--- a/zephyr/lib/regions_mm.c
+++ b/zephyr/lib/regions_mm.c
@@ -20,9 +20,8 @@ struct virtual_memory_heap
  * virtual first heaps.
  * Has to be initialized after calculations for regions is done in zephyr.
  */
-static int virtual_heaps_init(const struct device *unused)
+static int virtual_heaps_init(void)
 {
-	ARG_UNUSED(unused);
 
 	struct sys_mm_drv_region *virtual_memory_regions =
 		(struct sys_mm_drv_region *)sys_mm_drv_query_memory_regions();


### PR DESCRIPTION
Use the new call signature: int (*init_fn)(void);

Signed-off-by: Gerard Marull-Paretas <gerard.marull@nordicsemi.no>