### PR TITLE
zephyr: init: adjust SOF_MODULE_INIT

### DIFF
--- a/zephyr/include/rtos/init.h
+++ b/zephyr/include/rtos/init.h
@@ -9,9 +9,8 @@
 #include <zephyr/init.h>
 
 #define SOF_MODULE_INIT(name, init) \
-static int zephyr_##name##_init(const struct device *dev) \
+static int zephyr_##name##_init(void) \
 { \
-	ARG_UNUSED(dev); \
 	init(); \
 	return 0; \
 } \


### PR DESCRIPTION
Adjust SOF_MODULE_INIT so that new SYS_INIT signature is used.

Note: It looks like this went undetected in the last CI run.