### PR TITLE
common.h: Guard definition of IS_ALIGNED

### DIFF
--- a/src/include/sof/common.h
+++ b/src/include/sof/common.h
@@ -15,7 +15,11 @@
 #define __must_check __attribute__((warn_unused_result))
 
 /* Align the number to the nearest alignment value */
+#ifndef __ZEPHYR__
 #define IS_ALIGNED(size, alignment) ((size) % (alignment) == 0)
+#else
+#include <zephyr/sys/util.h>
+#endif
 
 /* Treat zero as a special case because it wraps around */
 #define is_power_of_2(x) ((x) && !((x) & ((x) - 1)))


### PR DESCRIPTION
common.h defines the IS_ALIGNED macro, which conflicts with a Zephyr macro of the same name. Add guards to define it only if it is not already defined by Zephyr.