### PR TITLE
zephyr: app: scripts: intel_adsp: change board names to HWMv2 [DNM]

### DIFF
--- a/app/sample.yaml
+++ b/app/sample.yaml
@@ -11,18 +11,18 @@ tests:
     tags: sof
     build_only: true
     platform_allow:
-      - intel_adsp_cavs25
-      - intel_adsp_ace15_mtpm
-      - intel_adsp_ace20_lnl
+      - intel_adsp/cavs25
+      - intel_adsp/ace15_mtpm
+      - intel_adsp/ace20_lnl
       - nxp_adsp_imx8
       - nxp_adsp_imx8x
       - nxp_adsp_imx8m
       - nxp_adsp_imx8ulp
 
     integration_platforms:
-      - intel_adsp_cavs25  # TGL
-      - intel_adsp_ace15_mtpm  # MTL
-      - intel_adsp_ace20_lnl
+      - intel_adsp/cavs25  # TGL
+      - intel_adsp/ace15_mtpm  # MTL
+      - intel_adsp/ace20_lnl
       - nxp_adsp_imx8
       - nxp_adsp_imx8x
       - nxp_adsp_imx8m

--- a/scripts/xtensa-build-zephyr.py
+++ b/scripts/xtensa-build-zephyr.py
@@ -90,7 +90,7 @@ class PlatformConfig:
 platform_configs_all = {
 	#  Intel platforms
 	"tgl" : PlatformConfig(
-		"intel", "intel_adsp_cavs25",
+		"intel", "intel_adsp/cavs25",
 		f"RG-2017.8{xtensa_tools_version_postfix}",
 		"cavs2x_LX6HiFi3_2017_8",
 		"xcc",
@@ -98,7 +98,7 @@ platform_configs_all = {
 		ipc4 = True
 	),
 	"tgl-h" : PlatformConfig(
-		"intel", "intel_adsp_cavs25_tgph",
+		"intel", "intel_adsp/cavs25/tgph",
 		f"RG-2017.8{xtensa_tools_version_postfix}",
 		"cavs2x_LX6HiFi3_2017_8",
 		"xcc",
@@ -106,14 +106,14 @@ platform_configs_all = {
 		ipc4 = True
 	),
 	"mtl" : PlatformConfig(
-		"intel", "intel_adsp_ace15_mtpm",
+		"intel", "intel_adsp/ace15_mtpm",
 		f"RI-2022.10{xtensa_tools_version_postfix}",
 		"ace10_LX7HiFi4_2022_10",
 		aliases = ['arl', 'arl-s'],
 		ipc4 = True
 	),
 	"lnl" : PlatformConfig(
-		"intel", "intel_adsp_ace20_lnl",
+		"intel", "intel_adsp/ace20_lnl",
 		f"RI-2022.10{xtensa_tools_version_postfix}",
 		"ace10_LX7HiFi4_2022_10",
 		ipc4 = True


### PR DESCRIPTION
replaced by #39 

Change `intel_adsp` board names to HWMv2 scheme:

  `intel_adsp_cavs25`     --> `intel_adsp/cavs25`
  `intel_adsp_ace15_mtpm` --> `intel_adsp/ace15_mtpm`
  `intel_adsp_ace20_lnl`  --> `intel_adsp/ace20_lnl`

Relates to https://github.com/zephyrproject-rtos/zephyr/pull/68412