### PR TITLE
zephyr: intel_adsp: HWMv2 alignments

### DIFF
--- a/app/sample.yaml
+++ b/app/sample.yaml
@@ -11,18 +11,18 @@ tests:
     tags: sof
     build_only: true
     platform_allow:
-      - intel_adsp_cavs25
-      - intel_adsp_ace15_mtpm
-      - intel_adsp_ace20_lnl
+      - intel_adsp/cavs25
+      - intel_adsp/ace15_mtpm
+      - intel_adsp/ace20_lnl
       - nxp_adsp_imx8
       - nxp_adsp_imx8x
       - nxp_adsp_imx8m
       - nxp_adsp_imx8ulp
 
     integration_platforms:
-      - intel_adsp_cavs25  # TGL
-      - intel_adsp_ace15_mtpm  # MTL
-      - intel_adsp_ace20_lnl
+      - intel_adsp/cavs25  # TGL
+      - intel_adsp/ace15_mtpm  # MTL
+      - intel_adsp/ace20_lnl
       - nxp_adsp_imx8
       - nxp_adsp_imx8x
       - nxp_adsp_imx8m

--- a/scripts/xtensa-build-zephyr.py
+++ b/scripts/xtensa-build-zephyr.py
@@ -90,7 +90,7 @@ class PlatformConfig:
 platform_configs_all = {
 	#  Intel platforms
 	"tgl" : PlatformConfig(
-		"intel", "intel_adsp_cavs25",
+		"intel", "intel_adsp/cavs25",
 		f"RG-2017.8{xtensa_tools_version_postfix}",
 		"cavs2x_LX6HiFi3_2017_8",
 		"xcc",
@@ -98,7 +98,7 @@ platform_configs_all = {
 		ipc4 = True
 	),
 	"tgl-h" : PlatformConfig(
-		"intel", "intel_adsp_cavs25_tgph",
+		"intel", "intel_adsp/cavs25/tgph",
 		f"RG-2017.8{xtensa_tools_version_postfix}",
 		"cavs2x_LX6HiFi3_2017_8",
 		"xcc",
@@ -106,14 +106,14 @@ platform_configs_all = {
 		ipc4 = True
 	),
 	"mtl" : PlatformConfig(
-		"intel", "intel_adsp_ace15_mtpm",
+		"intel", "intel_adsp/ace15_mtpm",
 		f"RI-2022.10{xtensa_tools_version_postfix}",
 		"ace10_LX7HiFi4_2022_10",
 		aliases = ['arl', 'arl-s'],
 		ipc4 = True
 	),
 	"lnl" : PlatformConfig(
-		"intel", "intel_adsp_ace20_lnl",
+		"intel", "intel_adsp/ace20_lnl",
 		f"RI-2022.10{xtensa_tools_version_postfix}",
 		"ace10_LX7HiFi4_2022_10",
 		ipc4 = True

--- a/src/audio/base_fw.c
+++ b/src/audio/base_fw.c
@@ -13,7 +13,7 @@
 #include <sof/lib/cpu.h>
 #include <rtos/init.h>
 #include <platform/lib/clk.h>
-#if defined(CONFIG_SOC_SERIES_INTEL_ACE)
+#if defined(CONFIG_SOC_SERIES_INTEL_ADSP_ACE)
 #include <intel_adsp_hda.h>
 #endif
 
@@ -24,7 +24,7 @@
 #include <zephyr/logging/log_ctrl.h>
 
 /* TODO: Remove platform-specific code, see https://github.com/thesofproject/sof/issues/7549 */
-#if defined(CONFIG_SOC_SERIES_INTEL_ACE) || defined(CONFIG_INTEL_ADSP_CAVS)
+#if defined(CONFIG_SOC_SERIES_INTEL_ADSP_ACE) || defined(CONFIG_INTEL_ADSP_CAVS)
 # define INTEL_ADSP 1
 #endif
 
@@ -421,7 +421,7 @@ static int basefw_power_state_info_get(uint32_t *data_offset, char *data)
 
 static int fw_config_set_force_l1_exit(const struct sof_tlv *tlv)
 {
-#if defined(CONFIG_SOC_SERIES_INTEL_ACE)
+#if defined(CONFIG_SOC_SERIES_INTEL_ADSP_ACE)
 	const uint32_t force = tlv->value[0];
 
 	if (force) {

--- a/src/ipc/CMakeLists.txt
+++ b/src/ipc/CMakeLists.txt
@@ -19,7 +19,7 @@ zephyr_library_sources(
 	dma-copy.c
 )
 
-if (CONFIG_SOC_SERIES_INTEL_CAVS_V25 OR CONFIG_SOC_SERIES_INTEL_ACE)
+if (CONFIG_SOC_SERIES_INTEL_CAVS_V25 OR CONFIG_SOC_SERIES_INTEL_ADSP_ACE)
 	zephyr_library_sources(
 		ipc-zephyr.c
 	)

--- a/src/ipc/ipc4/helper.c
+++ b/src/ipc/ipc4/helper.c
@@ -25,7 +25,7 @@
 #include <rtos/wait.h>
 
 /* TODO: Remove platform-specific code, see https://github.com/thesofproject/sof/issues/7549 */
-#if defined(CONFIG_SOC_SERIES_INTEL_ACE) || defined(CONFIG_INTEL_ADSP_CAVS)
+#if defined(CONFIG_SOC_SERIES_INTEL_ADSP_ACE) || defined(CONFIG_INTEL_ADSP_CAVS)
 #define RIMAGE_MANIFEST 1
 #endif
 

--- a/zephyr/CMakeLists.txt
+++ b/zephyr/CMakeLists.txt
@@ -178,7 +178,7 @@ if (CONFIG_SOC_SERIES_INTEL_CAVS_V25)
 endif()
 
 # Intel ACE 1.5 and newer platforms
-if (CONFIG_SOC_SERIES_INTEL_ACE)
+if (CONFIG_SOC_SERIES_INTEL_ADSP_ACE)
 
 	# Platform sources
 	zephyr_library_sources(


### PR DESCRIPTION
relates to https://github.com/zephyrproject-rtos/zephyr/pull/69335
also includes #38

1) SoC series ACE changes its name to align with HWMv2 new naming
conventions: `SOC_SERIES_INTEL_ACE` --> `SOC_SERIES_INTEL_ADSP_ACE`

2) Change intel_adsp board names to HWMv2 scheme:

`intel_adsp_cavs25` --> `intel_adsp/cavs25`
`intel_adsp_ace15_mtpm` --> `intel_adsp/ace15_mtpm`
`intel_adsp_ace20_lnl` --> `intel_adsp/ace20_lnl`