### PR TITLE
zephyr: Rename arch_sched_ipi() to arch_sched_broadcast_ipi()

### DIFF
--- a/zephyr/lib/cpu.c
+++ b/zephyr/lib/cpu.c
@@ -160,7 +160,7 @@ void cpu_disable_core(int id)
 		return;
 
 	/* Broadcasting interrupts to other cores. */
-	arch_sched_ipi();
+	arch_sched_broadcast_ipi();
 
 	uint64_t timeout = k_cycle_get_64() +
 		k_ms_to_cyc_ceil64(CONFIG_SECONDARY_CORE_DISABLING_TIMEOUT);


### PR DESCRIPTION
Renames arch_sched_ipi() to arch_sched_broadcast_ipi() to
reflect recent changes from the IPI optimization work done
in Zephyr.