### PR TITLE
zephyr: CMakeLists.txt: use new `CONFIG_SOC_` for 8ULP

### DIFF
--- a/zephyr/CMakeLists.txt
+++ b/zephyr/CMakeLists.txt
@@ -290,7 +290,7 @@ if (CONFIG_SOC_MIMX8MP_ADSP)
 	set(PLATFORM "imx8m")
 endif()
 
-if (CONFIG_SOC_MIMX8ULP_ADSP)
+if (CONFIG_SOC_MIMX8UD7_ADSP)
 	zephyr_library_sources(
 		${SOF_DRIVERS_PATH}/generic/dummy-dma.c
 		${SOF_DRIVERS_PATH}/imx/edma.c


### PR DESCRIPTION
Zephyr PR#70219 changes the SOC name of i.MX8ULP from MIMX8ULP to MIMX8UD7. This means that all `CONFIG_SOC_*` configurations will be changed from the `MIMX8ULP`-based naming to the `MIMX8UD7`-based naming. As such, this commit updates the name of the configuration used by the `zephyr/CMakeLists.txt` file.

This is a continuation of https://github.com/zephyrproject-rtos/sof/pull/43 required by https://github.com/zephyrproject-rtos/zephyr/pull/70219